### PR TITLE
fix: use prefix for XRP test net, not XRP main net

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ function pluginFromTestnet () {
       const credentials = {
         address: res.body.account.address,
         secret: res.body.account.secret,
-        server: 'wss://s.altnet.rippletest.net:51233'
+        server: 'wss://s.altnet.rippletest.net:51233',
+        prefix: 'test.crypto.xrp.'
       }
       fs.writeFileSync(getRc({ local: false }), JSON.stringify({
         plugin: 'ilp-plugin-xrp-escrow',


### PR DESCRIPTION
ilp-curl currently only works for shops that want to get paid on `g.crypto.ripple.escrow.`; but in the tutorials, we're using `test.crypto.xrp.` as the prefix to designate the XRP testnet.