### PR TITLE
Simplify export

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,4 @@ function pluginFromEnvironment (opts) {
   return new Plugin(credentials)
 }
 
-module.exports = function (opts) {
-  return pluginFromEnvironment(opts)
-}
+module.exports = pluginFromEnvironment


### PR DESCRIPTION
Just a minor thing. There's no need to define a new function that immediately calls another function.