### PR TITLE
feat: add ILP_BTP_SERVER env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,7 @@ First, the script checks whether `ILP_CREDENTIALS` is defined in the environment
 `ILP_CREDENTIALS` must contain a JSON object with the options passed into the
 constructor of `ilp-plugin-btp` or the module name in `ILP_PLUGIN`.
 
+Next, the script checks for the `ILP_BTP_SERVER` environment variable. `ILP_BTP_SERVER` must be a host. Using `ILP_BTP_SERVER` instead of `ILP_CREDENTIALS` ensures that each plugin gets a unique, random secret.
+
 By default, a random secret will be generated and the plugin will connect to
 `btp+ws://localhost:7768`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First, the script checks whether `ILP_CREDENTIALS` is defined in the environment
 `ILP_CREDENTIALS` must contain a JSON object with the options passed into the
 constructor of `ilp-plugin-btp` or the module name in `ILP_PLUGIN`.
 
-Next, the script checks for the `ILP_BTP_SERVER` environment variable. `ILP_BTP_SERVER` must be a host. Using `ILP_BTP_SERVER` instead of `ILP_CREDENTIALS` ensures that each plugin gets a unique, random secret.
+Next, the script checks for the `ILP_BTP_SERVER` environment variable. `ILP_BTP_SERVER` must be a URI with a protocol and host (e.g. `"btp+ws://localhost:7768"`). Using `ILP_BTP_SERVER` instead of `ILP_CREDENTIALS` ensures that each plugin gets a unique, random secret.
 
 By default, a random secret will be generated and the plugin will connect to
 `btp+ws://localhost:7768`.

--- a/index.js
+++ b/index.js
@@ -5,16 +5,24 @@ const crypto = require('crypto')
 
 function pluginFromEnvironment (opts) {
   const module = process.env.ILP_PLUGIN || 'ilp-plugin-btp'
-  const secret = require('crypto').randomBytes(16).toString('hex')
-  const name = (opts && opts.name) || ''
-  const credentials = process.env.ILP_CREDENTIALS
-    ? JSON.parse(process.env.ILP_CREDENTIALS)
-    : { server: `btp+ws://${name}:${secret}@localhost:7768` }
+  const credentials = generateCredentials(opts)
 
   log.debug('creating plugin with module', module)
   log.debug('creating plugin with credentials', credentials)
   const Plugin = require(module)
   return new Plugin(credentials)
+}
+
+function generateCredentials (opts) {
+  if (process.env.ILP_CREDENTIALS) {
+    return JSON.parse(process.env.ILP_CREDENTIALS)
+  }
+
+  const secret = require('crypto').randomBytes(16).toString('hex')
+  const name = (opts && opts.name) || ''
+  const server = process.env.ILP_BTP_SERVER || 'localhost:7768'
+
+  return { server: `btp+ws://${name}:${secret}@${server}` }
 }
 
 module.exports = pluginFromEnvironment

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const log = require('ilp-logger')('ilp-plugin')
 const crypto = require('crypto')
+const URL = require('url').URL
 
 function pluginFromEnvironment (opts) {
   const module = process.env.ILP_PLUGIN || 'ilp-plugin-btp'
@@ -20,9 +21,13 @@ function generateCredentials (opts) {
 
   const secret = require('crypto').randomBytes(16).toString('hex')
   const name = (opts && opts.name) || ''
-  const server = process.env.ILP_BTP_SERVER || 'localhost:7768'
 
-  return { server: `btp+ws://${name}:${secret}@${server}` }
+  if (process.env.ILP_BTP_SERVER) {
+    const url = new URL(process.env.ILP_BTP_SERVER)
+    return { server: `${url.protocol}//${name}:${secret}@${url.host}` }
+  }
+
+  return { server: `btp+ws://${name}:${secret}@$localhost:7768` }
 }
 
 module.exports = pluginFromEnvironment


### PR DESCRIPTION
Allow callers to specify a server host without the whole URI. This makes sure a random secret is still generated for each plugin.

When multiple plugins share a secret, they all get the same ilp address from mini-accounts, so all of them get passed each others' packets.